### PR TITLE
Improve URL reachability check

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -429,6 +429,8 @@ docker buildx build \
 
 Communicate with the running Docker server via its REST API (defaulting to `http://localhost:8080`). You can use the Python SDK or make direct HTTP requests.
 
+Before processing a request, the server quickly checks that each URL is reachable. It tries a `HEAD` request, then a short ranged `GET`, and finally a normal `GET` if needed. This fallback protects against sites that reject range requests so valid URLs are not mistakenly skipped.
+
 ### Playground Interface
 
 A built-in web playground is available at `http://localhost:8080/playground` for testing and generating API requests. The playground allows you to:


### PR DESCRIPTION
## Summary
- retry normal GET in `quick_url_check` after ranged GET fails
- explain fallback logic in docstring and comments
- mention URL precheck behavior in Docker README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684f1192e1208331b60bdc9ed327a5af