### PR TITLE
Set default page_timeout and enable skip_precheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ See the [Network Requests & Console Message Capturing guide](docs/md_v2/advanced
 
 ### Skipping URL Precheck
 
-The Docker API performs a quick connectivity test before crawling a page. Some servers reject these HEAD or range requests, causing the check to fail even though the page is reachable. Set `crawler.skip_precheck: true` in `deploy/docker/config.yml` (or `SKIP_PRECHECK=true` as an environment variable) to bypass this test. When enabled—or when the quick check fails—the server logs a warning and continues crawling.
+The Docker API performs a quick connectivity test before crawling a page. Some servers reject these HEAD or range requests, causing the check to fail even though the page is reachable. This check is skipped by default (`crawler.skip_precheck: true`). Set `crawler.skip_precheck: false` (or `SKIP_PRECHECK=false`) to re-enable the check. When disabled—or when the quick check fails—the server logs a warning and continues crawling.
 
 
 ## 📖 Documentation & Roadmap 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -709,7 +709,7 @@ security:
 # Crawler Configuration
 crawler:
   memory_threshold_percent: 95.0
-  skip_precheck: false # Skip quick connectivity test before crawling
+  skip_precheck: true # Skip quick connectivity test before crawling
   rate_limiter:
     base_delay: [1.0, 2.0] # Min/max delay between requests in seconds for dispatcher
   timeouts:
@@ -786,7 +786,7 @@ You can override the default `config.yml`.
 
 2. **Resource Management** 💻
    - Adjust memory_threshold_percent based on available RAM
-   - Set skip_precheck to `true` if servers block HEAD requests
+  - `skip_precheck` is enabled by default; set it to `false` if you want a quick connectivity check
    - Set timeouts according to your content size and network conditions
    - Use Redis for rate limiting in multi-container setups
 

--- a/deploy/docker/c4ai-code-context.md
+++ b/deploy/docker/c4ai-code-context.md
@@ -711,7 +711,7 @@ class CrawlerRunConfig():
         wait_until (str): The condition to wait for when navigating, e.g. "domcontentloaded".
                           Default: "domcontentloaded".
         page_timeout (int): Timeout in ms for page operations like navigation.
-                            Default: 60000 (60 seconds).
+                            Default: 3000 (3 seconds).
         wait_for (str or None): A CSS selector or JS condition to wait for before extracting content.
                                 Default: None.
         wait_for_images (bool): If True, wait for images to load before extracting content.

--- a/deploy/docker/config.yml
+++ b/deploy/docker/config.yml
@@ -50,8 +50,9 @@ security:
 crawler:
   base_config:
     simulate_user: true
+    page_timeout: 3000  # 3 seconds to quickly fail unreachable pages
   memory_threshold_percent: 95.0
-  skip_precheck: false
+  skip_precheck: true
   rate_limiter:
     enabled: true
     base_delay: [1.0, 2.0]

--- a/docs/md_v2/api/parameters.md
+++ b/docs/md_v2/api/parameters.md
@@ -102,7 +102,7 @@ Use these for controlling whether you read or write from a local content cache. 
 | **Parameter**              | **Type / Default**      | **What It Does**                                                                                                    |
 |----------------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------|
 | **`wait_until`**           | `str` (domcontentloaded)| Condition for navigation to “complete”. Often `"networkidle"` or `"domcontentloaded"`.                               |
-| **`page_timeout`**         | `int` (60000 ms)        | Timeout for page navigation or JS steps. Increase for slow sites.                                                    |
+| **`page_timeout`**         | `int` (3000 ms)        | Timeout for page navigation or JS steps. Increase for slow sites.                                                    |
 | **`wait_for`**             | `str or None`           | Wait for a CSS (`"css:selector"`) or JS (`"js:() => bool"`) condition before content extraction.                     |
 | **`wait_for_images`**      | `bool` (False)          | Wait for images to load before finishing. Slows down if you only want text.                                          |
 | **`delay_before_return_html`** | `float` (0.1)       | Additional pause (seconds) before final HTML is captured. Good for last-second updates.                               |


### PR DESCRIPTION
## Summary
- default to 3s `page_timeout` in docker config
- enable `skip_precheck` in docker config
- update docs to mention the new defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6851a07f676c8331a8ed3f0a523db3c9